### PR TITLE
Dynamic settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ python:
   - "3.5"
 
 env:
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py27-django-18
   - TOX_ENV=py35-django-19
   - TOX_ENV=py34-django-19
   - TOX_ENV=py27-django-19

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',

--- a/shared_schema_tenants/helpers/tenant_extra_data.py
+++ b/shared_schema_tenants/helpers/tenant_extra_data.py
@@ -1,5 +1,4 @@
-from shared_schema_tenants.settings import (
-    DEFAULT_TENANT_EXTRA_DATA_FIELDS, DEFAULT_TENANT_EXTRA_DATA)
+from shared_schema_tenants.settings import get_setting
 
 from shared_schema_tenants.helpers.tenant_json_field import TenantJSONFieldHelper
 
@@ -9,5 +8,5 @@ class TenantExtraDataHelper(TenantJSONFieldHelper):
     def __init__(self, instance=None):
         super(TenantExtraDataHelper, self).__init__(
             instance_field_name='extra_data', instance=instance,
-            tenant_fields=DEFAULT_TENANT_EXTRA_DATA_FIELDS,
-            tenant_default_fields_values=DEFAULT_TENANT_EXTRA_DATA)
+            tenant_fields=get_setting('DEFAULT_TENANT_EXTRA_DATA_FIELDS'),
+            tenant_default_fields_values=get_setting('DEFAULT_TENANT_EXTRA_DATA'))

--- a/shared_schema_tenants/helpers/tenant_relationships.py
+++ b/shared_schema_tenants/helpers/tenant_relationships.py
@@ -9,7 +9,7 @@ def create_relationship(tenant, user, groups=[], permissions=[]):
             relationship.groups.set(groups)
             relationship.permissions.set(permissions)
         except AttributeError:
-            # compatibility with old django 1.8 and 1.9
+            # compatibility with old django 1.9
             for group in groups:
                 relationship.groups.add(group)
             for perm in permissions:

--- a/shared_schema_tenants/helpers/tenant_settings.py
+++ b/shared_schema_tenants/helpers/tenant_settings.py
@@ -1,5 +1,4 @@
-from shared_schema_tenants.settings import (
-    DEFAULT_TENANT_SETTINGS_FIELDS, DEFAULT_TENANT_SETTINGS)
+from shared_schema_tenants.settings import get_setting
 
 from shared_schema_tenants.helpers.tenant_json_field import TenantJSONFieldHelper
 
@@ -9,5 +8,5 @@ class TenantSettingsHelper(TenantJSONFieldHelper):
     def __init__(self, instance=None):
         super(TenantSettingsHelper, self).__init__(
             instance_field_name='settings', instance=instance,
-            tenant_fields=DEFAULT_TENANT_SETTINGS_FIELDS,
-            tenant_default_fields_values=DEFAULT_TENANT_SETTINGS)
+            tenant_fields=get_setting('DEFAULT_TENANT_SETTINGS_FIELDS'),
+            tenant_default_fields_values=get_setting('DEFAULT_TENANT_SETTINGS'))

--- a/shared_schema_tenants/helpers/tenants.py
+++ b/shared_schema_tenants/helpers/tenants.py
@@ -2,7 +2,7 @@ from django.contrib.sites.models import Site
 from django.contrib.auth.models import Group, Permission
 from django.db import transaction
 
-from shared_schema_tenants.settings import DEFAULT_TENANT_OWNER_PERMISSIONS
+from shared_schema_tenants.settings import get_setting
 
 
 def get_current_tenant():
@@ -58,7 +58,7 @@ def create_default_tenant_groups():
         group, created = Group.objects.get_or_create(name='tenant_owner')
 
         if created:
-            for perm in DEFAULT_TENANT_OWNER_PERMISSIONS:
+            for perm in get_setting('DEFAULT_TENANT_OWNER_PERMISSIONS'):
                 try:
                     group.permissions.add(Permission.objects.get(
                         content_type__app_label=perm.split('.')[0],

--- a/shared_schema_tenants/middleware.py
+++ b/shared_schema_tenants/middleware.py
@@ -2,7 +2,7 @@ import platform
 from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.sites.models import Site
 from django.utils.functional import SimpleLazyObject
-from shared_schema_tenants.settings import TENANT_HTTP_HEADER
+from shared_schema_tenants.settings import get_setting
 from shared_schema_tenants.models import Tenant, TenantSite
 
 if platform.python_version_tuple()[0] == '2':
@@ -20,7 +20,7 @@ def get_tenant(request):
             pass
 
         try:
-            tenant_http_header = 'HTTP_' + TENANT_HTTP_HEADER.replace('-', '_').upper()
+            tenant_http_header = 'HTTP_' + get_setting('TENANT_HTTP_HEADER').replace('-', '_').upper()
             request._cached_tenant = Tenant.objects.get(slug=request.META[tenant_http_header])
         except LookupError:
             lazy_tenant = TenantMiddleware.get_current_tenant()

--- a/shared_schema_tenants/mixins.py
+++ b/shared_schema_tenants/mixins.py
@@ -1,12 +1,12 @@
 from django.db import models
 import django.utils.version
-from shared_schema_tenants.settings import DEFAULT_TENANT_SLUG
+from shared_schema_tenants.settings import get_setting
 from shared_schema_tenants.managers import SingleTenantModelManager, MultipleTenantModelManager
 from shared_schema_tenants.models import Tenant
 
 
 def get_default_tenant():
-    return Tenant.objects.filter(slug=DEFAULT_TENANT_SLUG).first()
+    return Tenant.objects.filter(slug=get_setting('DEFAULT_TENANT_SLUG')).first()
 
 
 class SingleTenantModelMixin(models.Model):

--- a/shared_schema_tenants/models.py
+++ b/shared_schema_tenants/models.py
@@ -9,7 +9,7 @@ from model_utils.models import TimeStampedModel
 
 from shared_schema_tenants.managers import (
     SingleTenantModelManager)
-from shared_schema_tenants.settings import DEFAULT_TENANT_SETTINGS, DEFAULT_TENANT_EXTRA_DATA
+from shared_schema_tenants.settings import get_setting
 from shared_schema_tenants.validators import validate_json
 
 
@@ -20,16 +20,16 @@ class Tenant(TimeStampedModel):
     if 'postgresql' in django_settings.DATABASES['default']['ENGINE']:
         from django.contrib.postgres.fields import JSONField
         extra_data = JSONField(blank=True, null=True,
-                               default=DEFAULT_TENANT_EXTRA_DATA)
+                               default=get_setting('DEFAULT_TENANT_EXTRA_DATA'))
         settings = JSONField(blank=True, null=True,
-                             default=DEFAULT_TENANT_SETTINGS)
+                             default=get_setting('DEFAULT_TENANT_SETTINGS'))
     else:
         _extra_data = models.TextField(blank=True, null=True,
                                        validators=[validate_json],
-                                       default=json.dumps(DEFAULT_TENANT_EXTRA_DATA))
+                                       default=json.dumps(get_setting('DEFAULT_TENANT_EXTRA_DATA')))
         _settings = models.TextField(blank=True, null=True,
                                      validators=[validate_json],
-                                     default=json.dumps(DEFAULT_TENANT_SETTINGS))
+                                     default=json.dumps(get_setting('DEFAULT_TENANT_SETTINGS')))
 
         @property
         def extra_data(self):

--- a/shared_schema_tenants/settings.py
+++ b/shared_schema_tenants/settings.py
@@ -1,67 +1,56 @@
 from django.conf import settings
 
-tenant_settings = getattr(settings, 'SHARED_SCHEMA_TENANTS', {})
 
+def get_setting(settings_name):
+    tenant_settings = getattr(settings, 'SHARED_SCHEMA_TENANTS', {})
+    settings_dict = {
 
-TENANT_SERIALIZER = (tenant_settings
-                     .get('SERIALIZERS', {})
-                     .get('TENANT_SERIALIZER',
-                          'shared_schema_tenants.serializers.TenantSerializer'))
-
-
-TENANT_SITE_SERIALIZER = (tenant_settings
-                          .get('SERIALIZERS', {})
-                          .get('TENANT_SITE_SERIALIZER',
-                               'shared_schema_tenants.serializers.TenantSiteSerializer'))
-
-TENANT_SETTINGS_SERIALIZER = (tenant_settings
+        "TENANT_SERIALIZER": (tenant_settings
                               .get('SERIALIZERS', {})
-                              .get('TENANT_SETTINGS_SERIALIZER',
-                                   'shared_schema_tenants.serializers.TenantSettingsSerializer'))
+                              .get('TENANT_SERIALIZER',
+                                   'shared_schema_tenants.serializers.TenantSerializer')),
+        "TENANT_SITE_SERIALIZER": (tenant_settings
+                                   .get('SERIALIZERS', {})
+                                   .get('TENANT_SITE_SERIALIZER',
+                                        'shared_schema_tenants.serializers.TenantSiteSerializer')),
+        "TENANT_SETTINGS_SERIALIZER": (tenant_settings
+                                       .get('SERIALIZERS', {})
+                                       .get('TENANT_SETTINGS_SERIALIZER',
+                                            'shared_schema_tenants.serializers.TenantSettingsSerializer')),
+        "TENANT_RELATIONSHIP_SERIALIZER": (
+            tenant_settings
+            .get('SERIALIZERS', {})
+            .get('TENANT_SITE_SERIALIZER',
+                'shared_schema_tenants.serializers.TenantSiteSerializer')),
+        "DEFAULT_TENANT_SETTINGS_FIELDS": tenant_settings.get(
+            'DEFAULT_TENANT_SETTINGS_FIELDS', {}),
+        "DEFAULT_TENANT_SETTINGS": {key: value.get('default')
+                                    for key, value
+                                    in DEFAULT_TENANT_SETTINGS_FIELDS.items()},
+        "DEFAULT_TENANT_EXTRA_DATA_FIELDS": tenant_settings.get(
+            'DEFAULT_TENANT_EXTRA_DATA_FIELDS',
+            {}),
+        "DEFAULT_TENANT_EXTRA_DATA": {key: value.get('default')
+                                      for key, value
+                                      in DEFAULT_TENANT_EXTRA_DATA_FIELDS.items()},
+        "DEFAULT_SITE_DOMAIN": tenant_settings.get(
+            'DEFAULT_SITE_DOMAIN',
+            'localhost'
+        ),
+        "DEFAULT_TENANT_SLUG": tenant_settings.get(
+            'DEFAULT_TENANT_SLUG',
+            'default'
+        ),
+        "TENANT_HTTP_HEADER": tenant_settings.get('TENANT_HTTP_HEADER', 'Tenant-Slug'),
+        "DEFAULT_TENANT_OWNER_PERMISSIONS": tenant_settings.get(
+            'DEFAULT_TENANT_OWNER_PERMISSIONS', [
+                'shared_schema_tenants.add_tenantsite',
+                'shared_schema_tenants.change_tenantsite',
+                'shared_schema_tenants.delete_tenantsite',
+                'shared_schema_tenants.add_tenantrelationship',
+                'shared_schema_tenants.delete_tenantrelationship',
+                'shared_schema_tenants.change_tenantrelationship',
+            ])
+    }
 
-TENANT_RELATIONSHIP_SERIALIZER = (
-    tenant_settings
-    .get('SERIALIZERS', {})
-    .get('TENANT_SITE_SERIALIZER',
-         'shared_schema_tenants.serializers.TenantSiteSerializer'))
-
-
-DEFAULT_TENANT_SETTINGS_FIELDS = tenant_settings.get(
-    'DEFAULT_TENANT_SETTINGS_FIELDS', {})
-
-
-DEFAULT_TENANT_SETTINGS = {key: value.get('default')
-                           for key, value
-                           in DEFAULT_TENANT_SETTINGS_FIELDS.items()}
-
-
-DEFAULT_TENANT_EXTRA_DATA_FIELDS = tenant_settings.get(
-    'DEFAULT_TENANT_EXTRA_DATA_FIELDS',
-    {})
-
-DEFAULT_TENANT_EXTRA_DATA = {key: value.get('default')
-                             for key, value
-                             in DEFAULT_TENANT_EXTRA_DATA_FIELDS.items()}
-
-DEFAULT_SITE_DOMAIN = tenant_settings.get(
-    'DEFAULT_SITE_DOMAIN',
-    'localhost'
-)
-
-DEFAULT_TENANT_SLUG = tenant_settings.get(
-    'DEFAULT_TENANT_SLUG',
-    'default'
-)
-
-TENANT_HTTP_HEADER = tenant_settings.get('TENANT_HTTP_HEADER', 'Tenant-Slug')
-
-
-DEFAULT_TENANT_OWNER_PERMISSIONS = tenant_settings.get(
-    'DEFAULT_TENANT_OWNER_PERMISSIONS', [
-        'shared_schema_tenants.add_tenantsite',
-        'shared_schema_tenants.change_tenantsite',
-        'shared_schema_tenants.delete_tenantsite',
-        'shared_schema_tenants.add_tenantrelationship',
-        'shared_schema_tenants.delete_tenantrelationship',
-        'shared_schema_tenants.change_tenantrelationship',
-    ])
+    return settings_dict.get(settings_name)

--- a/shared_schema_tenants/settings.py
+++ b/shared_schema_tenants/settings.py
@@ -3,8 +3,12 @@ from django.conf import settings
 
 def get_setting(settings_name):
     tenant_settings = getattr(settings, 'SHARED_SCHEMA_TENANTS', {})
-    settings_dict = {
+    DEFAULT_TENANT_SETTINGS_FIELDS = tenant_settings.get(
+        'DEFAULT_TENANT_SETTINGS_FIELDS', {})
+    DEFAULT_TENANT_EXTRA_DATA_FIELDS = tenant_settings.get(
+        'DEFAULT_TENANT_EXTRA_DATA_FIELDS', {}),
 
+    settings_dict = {
         "TENANT_SERIALIZER": (tenant_settings
                               .get('SERIALIZERS', {})
                               .get('TENANT_SERIALIZER',
@@ -21,15 +25,12 @@ def get_setting(settings_name):
             tenant_settings
             .get('SERIALIZERS', {})
             .get('TENANT_SITE_SERIALIZER',
-                'shared_schema_tenants.serializers.TenantSiteSerializer')),
-        "DEFAULT_TENANT_SETTINGS_FIELDS": tenant_settings.get(
-            'DEFAULT_TENANT_SETTINGS_FIELDS', {}),
+                 'shared_schema_tenants.serializers.TenantSiteSerializer')),
+        "DEFAULT_TENANT_SETTINGS_FIELDS": DEFAULT_TENANT_SETTINGS_FIELDS,
         "DEFAULT_TENANT_SETTINGS": {key: value.get('default')
                                     for key, value
                                     in DEFAULT_TENANT_SETTINGS_FIELDS.items()},
-        "DEFAULT_TENANT_EXTRA_DATA_FIELDS": tenant_settings.get(
-            'DEFAULT_TENANT_EXTRA_DATA_FIELDS',
-            {}),
+        "DEFAULT_TENANT_EXTRA_DATA_FIELDS": DEFAULT_TENANT_EXTRA_DATA_FIELDS,
         "DEFAULT_TENANT_EXTRA_DATA": {key: value.get('default')
                                       for key, value
                                       in DEFAULT_TENANT_EXTRA_DATA_FIELDS.items()},

--- a/shared_schema_tenants/settings.py
+++ b/shared_schema_tenants/settings.py
@@ -6,7 +6,7 @@ def get_setting(settings_name):
     DEFAULT_TENANT_SETTINGS_FIELDS = tenant_settings.get(
         'DEFAULT_TENANT_SETTINGS_FIELDS', {})
     DEFAULT_TENANT_EXTRA_DATA_FIELDS = tenant_settings.get(
-        'DEFAULT_TENANT_EXTRA_DATA_FIELDS', {}),
+        'DEFAULT_TENANT_EXTRA_DATA_FIELDS', {})
 
     settings_dict = {
         "TENANT_SERIALIZER": (tenant_settings

--- a/shared_schema_tenants/views.py
+++ b/shared_schema_tenants/views.py
@@ -4,20 +4,15 @@ from django.db import transaction
 from shared_schema_tenants.models import Tenant, TenantSite
 from shared_schema_tenants.permissions import DjangoTenantModelPermissions
 from shared_schema_tenants.utils import import_class
-from shared_schema_tenants.settings import (
-    TENANT_SERIALIZER, TENANT_SITE_SERIALIZER,
-    TENANT_SETTINGS_SERIALIZER)
+from shared_schema_tenants.settings import get_setting
 from shared_schema_tenants.helpers.tenants import get_current_tenant
 
 
-TenantSerializer = import_class(TENANT_SERIALIZER)
-TenantSiteSerializer = import_class(TENANT_SITE_SERIALIZER)
-TenantSettingsSerializer = import_class(TENANT_SETTINGS_SERIALIZER)
-
-
 class TenantListView(generics.ListCreateAPIView):
-    serializer_class = TenantSerializer
     permission_classes = [DjangoTenantModelPermissions]
+
+    def get_serializer_class(self):
+        return import_class(get_setting('TENANT_SERIALIZER'))
 
     def get_queryset(self):
         if self.request.user.is_authenticated:
@@ -28,8 +23,10 @@ class TenantListView(generics.ListCreateAPIView):
 
 
 class TenantDetailsView(generics.RetrieveUpdateDestroyAPIView):
-    serializer_class = TenantSerializer
     permission_classes = [DjangoTenantModelPermissions]
+
+    def get_serializer_class(self):
+        return import_class(get_setting('TENANT_SERIALIZER'))
 
     def get_queryset(self):
         if self.request.user.is_authenticated:
@@ -43,8 +40,10 @@ class TenantDetailsView(generics.RetrieveUpdateDestroyAPIView):
 
 
 class TenantSettingsDetailsView(views.APIView):
-    serializer_class = TenantSettingsSerializer
     permission_classes = [DjangoTenantModelPermissions]
+
+    def get_serializer_class(self):
+        return import_class(get_setting('TENANT_SETTINGS_SERIALIZER'))
 
     def get(self, request, *args, **kwargs):
         serializer = self.get_serializer_class(
@@ -64,8 +63,10 @@ class TenantSettingsDetailsView(views.APIView):
 
 
 class TenantSiteListView(generics.ListCreateAPIView):
-    serializer_class = TenantSiteSerializer
     permission_classes = [DjangoTenantModelPermissions]
+
+    def get_serializer_class(self):
+        return import_class(get_setting('TENANT_SITE_SERIALIZER'))
 
     def get_queryset(self):
         return TenantSite.objects.filter().distinct()
@@ -78,8 +79,10 @@ class TenantSiteListView(generics.ListCreateAPIView):
 
 
 class TenantSiteDetailsView(generics.DestroyAPIView):
-    serializer_class = TenantSiteSerializer
     permission_classes = [DjangoTenantModelPermissions]
+
+    def get_serializer_class(self):
+        return import_class(get_setting('TENANT_SITE_SERIALIZER'))
 
     def get_queryset(self):
         return TenantSite.objects.filter().distinct()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django-18
     {py27,py34,py35}-django-19
     {py27,py34,py35}-django-110
     {py27,py34,py35}-django-111
@@ -10,7 +9,6 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/shared_schema_tenants
 commands = coverage run --source shared_schema_tenants runtests.py {posargs}
 deps =
-    django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11


### PR DESCRIPTION
The old settings flow wasn't getting the correct values for settings that were updated in runtime.

The main problem this leads to is with testing, because we can't override settings with django `override_settings` decorator. 

This created a new flow, where settings are now picked from a `get_setting` helper passing the settings name as a string. This grants that we always have the correct value for settings. 